### PR TITLE
[feature] 메인페이지 taps, textbox 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .nextra/
 .pnpm-lock.yaml
 .next/
+!node_modules/nextra/dist/components/tabs.js
 
 # macOS
 .DS_Store

--- a/components/Tabs.js
+++ b/components/Tabs.js
@@ -1,0 +1,83 @@
+// src/components/tabs.tsx
+import { Tab as HeadlessTab } from "@headlessui/react"
+import cn from "clsx"
+import { useCallback, useEffect, useState } from "react"
+import { jsx, jsxs } from "react/jsx-runtime"
+function isTabObjectItem(item) {
+  return !!item && typeof item === "object" && "label" in item
+}
+function _Tabs({ items, selectedIndex: _selectedIndex, defaultIndex = 0, onChange, children, storageKey }) {
+  const [selectedIndex, setSelectedIndex] = useState(defaultIndex)
+  useEffect(() => {
+    if (_selectedIndex !== void 0) {
+      setSelectedIndex(_selectedIndex)
+    }
+  }, [_selectedIndex])
+  useEffect(() => {
+    if (!storageKey) {
+      return
+    }
+    function fn(event) {
+      if (event.key === storageKey) {
+        setSelectedIndex(Number(event.newValue))
+      }
+    }
+    const index = Number(localStorage.getItem(storageKey))
+    setSelectedIndex(Number.isNaN(index) ? 0 : index)
+    window.addEventListener("storage", fn)
+    return () => {
+      window.removeEventListener("storage", fn)
+    }
+  }, [])
+  const handleChange = useCallback((index) => {
+    if (storageKey) {
+      const newValue = String(index)
+      localStorage.setItem(storageKey, newValue)
+      window.dispatchEvent(new StorageEvent("storage", { key: storageKey, newValue }))
+      return
+    }
+    setSelectedIndex(index)
+    onChange?.(index)
+  }, [])
+  return /* @__PURE__ */ jsxs(HeadlessTab.Group, {
+    selectedIndex,
+    defaultIndex,
+    onChange: handleChange,
+    children: [
+      /* @__PURE__ */ jsx("div", {
+        className: "nextra-scrollbar",
+        style: { width: "100%" },
+        children: /* @__PURE__ */ jsx(HeadlessTab.List, {
+          className:
+            "nx-mt-4 nx-flex nx-justify-between nx-w-max nx-min-w-full nx-border-b nx-border-gray-200 nx-pb-px dark:nx-border-neutral-800",
+          children: items.map((item, index) => {
+            const disabled = isTabObjectItem(item) && item.disabled
+            return /* @__PURE__ */ jsx(
+              HeadlessTab,
+              {
+                disabled,
+                className: ({ selected }) =>
+                  cn(
+                    "nx-w-full nx-mr-2 nx-rounded-t nx-p-2 nx-font-medium nx-leading-5 nx-transition-colors",
+                    "-nx-mb-0.5 nx-select-none nx-border-b-2",
+                    selected
+                      ? "nx-border-primary-500 nx-text-primary-600"
+                      : "nx-border-transparent nx-text-gray-600 hover:nx-border-gray-200 hover:nx-text-black dark:nx-text-gray-200 dark:hover:nx-border-neutral-800 dark:hover:nx-text-white",
+                    disabled && "nx-pointer-events-none nx-text-gray-400 dark:nx-text-neutral-600"
+                  ),
+                children: isTabObjectItem(item) ? item.label : item,
+              },
+              index
+            )
+          }),
+        }),
+      }),
+      /* @__PURE__ */ jsx(HeadlessTab.Panels, { children }),
+    ],
+  })
+}
+function Tab({ children, ...props }) {
+  return /* @__PURE__ */ jsx(HeadlessTab.Panel, { ...props, className: "nx-w-full nx-rounded nx-pt-6", children })
+}
+var ChangeTabs = Object.assign(_Tabs, { displayName: "Tabs", Tab })
+export { Tab, ChangeTabs }

--- a/components/TextBox.mdx
+++ b/components/TextBox.mdx
@@ -1,0 +1,11 @@
+export default function TextBox ({title, content}) {
+  return (
+
+    <div>
+      <p style={{fontSize: '1.4rem', fontWeight: "700"}}>{title}</p>
+      <p style={{marginTop:'0.3rem'}} dangerouslySetInnerHTML={{ __html: content }} />
+    </div>
+
+)
+
+}

--- a/pages/_app.mdx
+++ b/pages/_app.mdx
@@ -1,4 +1,3 @@
-
 export default function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return <Component {...pageProps} />
 }

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -3,7 +3,7 @@ sidebar: false
 toc: false
 ---
 
-import { Tabs } from "nextra/components"
+import { ChangeTabs } from "../components/Tabs"
 import TextBox from "../components/TextBox.mdx"
 
 <h1 style={{ textAlign: "center", fontSize: "2.8rem", fontWeight: "700" }}>BYULHOOK</h1>
@@ -12,8 +12,8 @@ import TextBox from "../components/TextBox.mdx"
 <div style={{width: '100%',display:'flex', justifyContent:'center', alignItems:'center', flexDirection:'column'}}>
 <div style={{width: '70%',display:'flex', justifyContent:'center', alignItems:'center', flexDirection:'column'}}>
 <div style={{ width: '100%' }}>
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
-  <Tabs.Tab label="npm">
+<ChangeTabs items={["npm", "pnpm", "yarn", "bun"]}>
+  <ChangeTabs.Tab label="npm">
 
       <code style={{display:'block',width: '100%'}}>
       ```js copy
@@ -21,8 +21,8 @@ import TextBox from "../components/TextBox.mdx"
       ```
       </code>
 
-  </Tabs.Tab>
-  <Tabs.Tab label="pnpm">
+  </ChangeTabs.Tab>
+  <ChangeTabs.Tab label="pnpm">
 
       <code>
       ```js copy
@@ -30,8 +30,8 @@ import TextBox from "../components/TextBox.mdx"
       ```
       </code>
 
-  </Tabs.Tab>
-  <Tabs.Tab label="yarn">
+  </ChangeTabs.Tab>
+  <ChangeTabs.Tab label="yarn">
 
       <code>
       ```js copy
@@ -39,8 +39,8 @@ import TextBox from "../components/TextBox.mdx"
       ```
       </code>
 
-  </Tabs.Tab>
-  <Tabs.Tab label="bun">
+  </ChangeTabs.Tab>
+  <ChangeTabs.Tab label="bun">
 
       <code>
       ```js copy
@@ -48,8 +48,8 @@ import TextBox from "../components/TextBox.mdx"
       ```
       </code>
 
-  </Tabs.Tab>
-</Tabs>
+  </ChangeTabs.Tab>
+</ChangeTabs>
 </div>
 </div>
 </div>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -4,15 +4,18 @@ toc: false
 ---
 
 import { Tabs } from "nextra/components"
+import TextBox from "../components/TextBox.mdx"
 
-<h1 style={{ textAlign: "center", fontSize: "2.7rem", fontWeight: "700" }}>BYULHOOK</h1>
+<h1 style={{ textAlign: "center", fontSize: "2.8rem", fontWeight: "700" }}>BYULHOOK</h1>
 
 <h2 style={{ textAlign: "center", margin: "40px 0" }}>Easy-to-Customize Git Hooks Manager</h2>
-
+<div style={{width: '100%',display:'flex', justifyContent:'center', alignItems:'center', flexDirection:'column'}}>
+<div style={{width: '70%',display:'flex', justifyContent:'center', alignItems:'center', flexDirection:'column'}}>
+<div style={{ width: '100%' }}>
 <Tabs items={["npm", "pnpm", "yarn", "bun"]}>
   <Tabs.Tab label="npm">
 
-      <code>
+      <code style={{display:'block',width: '100%'}}>
       ```js copy
       npm install byulhook
       ```
@@ -47,8 +50,10 @@ import { Tabs } from "nextra/components"
 
   </Tabs.Tab>
 </Tabs>
-
-<div style={{width: '100%',height: '100px' ,display:'flex', justifyContent:'center', alignItems:'center'}}>
+</div>
+</div>
+</div>
+<div style={{marginTop:'3rem',width: '100%',display:'flex', justifyContent:'center', alignItems:'center'}}>
 <a href="/docs/introduction">
   <button style={{
     padding: '5px 35px',
@@ -63,4 +68,11 @@ Get Started
 
   </button>
 </a>
+</div>
+
+<div style={{marginTop:'6rem',width: '100%',display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+<TextBox title='Super Fast' content='Customizable for Easy<br/>Creation of Various Features<br/>Manage Git Hooks Easily'/>
+<TextBox title='Super Fast' content='Customizable for Easy<br/>Creation of Various Features<br/>Manage Git Hooks Easily'/>
+<TextBox title='Super Fast' content='Customizable for Easy<br/>Creation of Various Features<br/>Manage Git Hooks Easily'/>
+
 </div>

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -1,20 +1,20 @@
 export default {
-    logo: (
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-            <img
-                src="/logo.png"  // 루트 디렉토리에 있는 logo.png 파일 경로
-                style={{ height: '32px', width: '32px',  marginRight: '8px' }}  // 이미지 크기 및 간격 조정
-            />
-            <strong>BYULHOOK</strong>
-        </div>
-    ),
-    project: {
-        link: 'https://github.com/byulhook/byulhook',
-    },
-    footer: {
-        text: '© 2024 BYULHOOK. All rights reserved.',
-    },
-    pages: {
-        '/': 'index.mdx'
-    },
+  logo: (
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <img
+        src="/logo.png" // 루트 디렉토리에 있는 logo.png 파일 경로
+        style={{ height: "32px", width: "32px", marginRight: "8px" }} // 이미지 크기 및 간격 조정
+      />
+      <strong>BYULHOOK</strong>
+    </div>
+  ),
+  project: {
+    link: "https://github.com/byulhook/byulhook",
+  },
+  footer: {
+    text: "© 2024 BYULHOOK. All rights reserved.",
+  },
+  pages: {
+    "/": "index.mdx",
+  },
 }


### PR DESCRIPTION
# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**

## 📋 Work Details

 메인페이지 taps, textbox 구성

## 🔧 Changes Summary

 메인페이지 taps, textbox 구성

## 📸 Screenshots (Optional)

You can attach screenshots demonstrating the modified screens or features.

## 📄 Additional Information

If you have any additional information or special requests, please include them here.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
## Release Notes

### New Feature
- `Tabs` 및 `Tab` 컴포넌트 추가: 선택된 탭을 localStorage에 저장하고 다른 창과 동기화하는 기능 포함.
- `TextBox` 컴포넌트 추가: `title`과 `content`를 받아 `<div>`로 반환.

### Refactor
- 메인 페이지의 `Tabs` 컴포넌트를 `ChangeTabs`로 대체하고 스타일 및 레이아웃 변경.
- `_app.mdx`에서 함수 서명 변경.

### Chore
- `.gitignore`에 `node_modules/nextra/dist/components/tabs.js` 추가.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->